### PR TITLE
Removed tasksel for lamp-server metapackage

### DIFF
--- a/provisioning/roles/common/tasks/main.yml
+++ b/provisioning/roles/common/tasks/main.yml
@@ -39,7 +39,8 @@
   sudo:           yes
 
 - name:           Install LAMP stack
-  shell:          DEBIAN_FRONTEND=noninteractive tasksel install lamp-server
+  apt:            pkg={{item}}
+  with_items:     lamp_packages
   sudo:           yes
 
 - name:           Install PHP packages

--- a/provisioning/roles/common/vars/main.yml
+++ b/provisioning/roles/common/vars/main.yml
@@ -11,3 +11,27 @@ system_packages:
   - postfix
   - htop
   - iftop
+lamp_packages:
+  - libmysqlclient18
+  - apache2
+  - php5-cli
+  - apache2.2-common
+  - apache2-utils
+  - php5-common
+  - mysql-server
+  - apache2.2-bin
+  - libapr1
+  - mysql-server-core-5.5
+  - apache2-mpm-prefork
+  - libwrap0
+  - libaprutil1-dbd-sqlite3
+  - tcpd
+  - libapache2-mod-php5
+  - libaprutil1
+  - php5-mysql
+  - mysql-client-5.5
+  - mysql-server-5.5
+  - libcap2
+  - mysql-client-core-5.5
+  - ssl-cert
+  - mysql-common


### PR DESCRIPTION
Re-provisioning of an existing server was failing on the `tasksel install` of the `lamp-server` metapackage (despite apt having an up to date cache):

```
 ** [out :: staging.example.com] TASK: [common | Install LAMP stack] *******************************************
 ** [out :: staging.example.com] failed: [127.0.0.1] => {"changed": true, "cmd": "DEBIAN_FRONTEND=noninteractive tasksel install lamp-server ", "delta": "0:00:02.809871", "end": "2015-04-21 10:12:12.324792", "item": "", "rc": 1, "start": "2015-04-21 10:12:09.514921"}
 ** [out :: staging.example.com] stderr: tasksel: aptitude failed (100)
```

Easiest solution for the time being is to bypass `tasksel` altogether, and just install the necessary packages with apt.