### PR TITLE
Deleting files on `up` file sync

### DIFF
--- a/deployment/lib/sync.rb
+++ b/deployment/lib/sync.rb
@@ -121,7 +121,7 @@ namespace :genesis do
 
             find_servers_for_task(current_task).each do |current_server|
                 system "chmod 600 #{ssh_options[:keys][0]}" unless ssh_options.keys.empty?
-                system "rsync -e \"ssh -i #{ssh_options[:keys][0]}\" -avvru --keep-dirlinks #{excludes} --progress #{'--dry-run' if dry_run} #{local_web}/ #{user}@#{current_server}:#{remote_web}/"
+                system "rsync -e \"ssh -i #{ssh_options[:keys][0]}\" -avvru --delete --copy-links #{excludes} --progress #{'--dry-run' if dry_run} #{local_web}/ #{user}@#{current_server}:#{remote_web}/"
             end
         end
 
@@ -132,7 +132,7 @@ namespace :genesis do
             find_servers_for_task(current_task).each do |current_server|
                 system "chmod 600 #{ssh_options[:keys][0]}" unless ssh_options.keys.empty?
                 rsync_limited.each do |key|
-                    system "rsync -e \"ssh -i #{ssh_options[:keys][0]}\" -avvru --keep-dirlinks #{excludes} --progress #{'--dry-run' if dry_run} #{local_web}/#{key}/ #{user}@#{current_server}:#{remote_web}/#{key}/"
+                    system "rsync -e \"ssh -i #{ssh_options[:keys][0]}\" -avvru --delete --copy-links #{excludes} --progress #{'--dry-run' if dry_run} #{local_web}/#{key}/ #{user}@#{current_server}:#{remote_web}/#{key}/"
                 end
             end
         end


### PR DESCRIPTION
It appears that, on sync from remote to local, we _are_ [removing any destination files that don't exist on source](https://github.com/genesis/wordpress/blob/master/deployment/lib/sync.rb#L75).

However, on sync from local to remote, [we are _not_](https://github.com/genesis/wordpress/blob/master/deployment/lib/sync.rb#L124).

/cc @ericrasch 