### PR TITLE
Add `backup` task to `:up:db`

### DIFF
--- a/deployment/lib/sync.rb
+++ b/deployment/lib/sync.rb
@@ -122,6 +122,9 @@ namespace :genesis do
 
         desc "Uploads Vagrant database into remote"
         task :db, :roles => :db, :once => true do
+            find_and_execute_task "genesis:backup:db"
+            sleep(1)
+
             set :backup_dir,  "#{deploy_to}/backups"
             set :backup_name, DateTime.now.strftime("#{db_name}.%Y-%m-%d.%H%M%S.sql")
             set :backup_path, "#{backup_dir}/#{backup_name}"


### PR DESCRIPTION
Currently, from what I can tell, running `genesis:up` (or `genesis:up:db`) overrides the staging/prod db without generating a backup: https://github.com/genesis/wordpress/blob/master/deployment/lib/sync.rb#L123-L138 

Right now, we've got a "missing posts" issue with nursing.org staging. I haven't been able to to pin it down to any `:up` commands being run, but it does seem like a useful thing to create a backup of the staging db before overriding it with local. Two ways we could do that: 

1. Create it on the server in `/#{deploy-branch}/backups/` (something already created a few .sql files there for nursing, but I'm not sure what) - we'll want to figure out how to keep just a few to prevent server bloat with sql dumps.
2. Create it locally on the dev's machine (using the existing `:backup` task w/no modification)

Thoughts?