### PR TITLE
Smarter log management, via logrotate

### DIFF
--- a/provisioning/roles/common/files/logrotate-apache
+++ b/provisioning/roles/common/files/logrotate-apache
@@ -1,0 +1,18 @@
+/var/log/apache2/*.log {
+  size 100M
+  missingok
+  rotate 10
+  compress
+  delaycompress
+  notifempty
+  create 640 root adm
+  sharedscripts
+  postrotate
+    /etc/init.d/apache2 reload > /dev/null
+  endscript
+  prerotate
+    if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
+      run-parts /etc/logrotate.d/httpd-prerotate; \
+    fi; \
+  endscript
+}

--- a/provisioning/roles/common/tasks/main.yml
+++ b/provisioning/roles/common/tasks/main.yml
@@ -43,6 +43,17 @@
   with_items:     lamp_packages
   sudo:           yes
 
+- name:           Configure apache log rotation
+  copy:           src=logrotate-apache dest=/etc/logrotate.d/apache2 owner=root group=root mode=644
+  sudo:           yes
+
+- name:           Ensure logrotate runs hourly
+  command:        mv /etc/cron.daily/logrotate /etc/cron.hourly/logrotate
+  args:
+    creates:      /etc/cron.hourly/logrotate
+    removes:      /etc/cron.daily/logrotate
+  sudo:           yes
+
 - name:           Install PHP packages
   apt:            pkg={{item}}
   with_items:     php_packages


### PR DESCRIPTION
Apache logs should be rotated at a size threshold (100MB), and more often than once a day if necessary